### PR TITLE
if first arg is invalid env, should not print space

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -45,7 +45,7 @@ static int	builtin_echo(t_mini *mini, char **argv)
 	while (argv[i])
 	{
 		printf("%s", argv[i]);
-		if (argv[i + 1])
+		if (argv[i + 1] && argv[i][0] != '\0')
 			printf(" ");
 		i++;
 	}


### PR DESCRIPTION
new
> echo $QQ aaa
aaa

old
> echo $QQ aaa
_aaa

spaceの出力をなくしました