### PR TITLE
fix: update parent process to handle child exit status correctly

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -6,7 +6,7 @@
 /*   By: nkannan <nkannan@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 17:08:33 by nkannan           #+#    #+#             */
-/*   Updated: 2024/12/10 19:06:30 by nkannan          ###   ########.fr       */
+/*   Updated: 2024/12/10 19:25:31 by nkannan          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -166,7 +166,9 @@ void	child_process(t_mini *mini, int pipefd[][2], int process, int p_num)
 void	parent_process(t_mini *mini, int pipefd[][2], int process, int pid[])
 {
 	int	closer;
+	int	raw_status;
 
+	// パイプクローズ
 	closer = 0;
 	while (closer < process - 1)
 	{
@@ -174,11 +176,23 @@ void	parent_process(t_mini *mini, int pipefd[][2], int process, int pid[])
 		close(pipefd[closer][1]);
 		closer++;
 	}
+
+	// 子プロセスの終了待ちとステータス更新
 	closer = 0;
 	while (closer < process)
-		waitpid(pid[closer++], &(mini->status), 0);
+	{
+		waitpid(pid[closer], &raw_status, 0);
+		if (WIFEXITED(raw_status))
+			mini->status = WEXITSTATUS(raw_status);
+		else if (WIFSIGNALED(raw_status))
+			mini->status = 128 + WTERMSIG(raw_status);
+		else
+			mini->status = raw_status; // 想定外だが保険的処理
+		closer++;
+	}
 	return ;
 }
+
 
 void	prepare_pipe(t_mini *mini, int process, int pipefd[][2])
 {


### PR DESCRIPTION
- **修正点**:
  1. `waitpid()`後、返却された`raw_status`を判定し、`WIFEXITED`の場合は`WEXITSTATUS`で終了コードを取り出します。
  2. `WIFSIGNALED`の場合はシグナル終了コード(`128 + シグナル番号`)を設定します。

この変更により、`grep`がマッチしなかった場合には`bash`と同様の終了コード`1`が`mini->status`に正しく格納されるようになります。これがテスト失敗 (`256` ではなく `1`) を修正するための主なポイントです。