### PR TITLE
#36 fix/redirect error code

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -6,7 +6,7 @@
 /*   By: nkannan <nkannan@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 17:08:33 by nkannan           #+#    #+#             */
-/*   Updated: 2024/12/10 20:36:57 by nkannan          ###   ########.fr       */
+/*   Updated: 2024/12/10 21:26:11 by nkannan          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -138,14 +138,23 @@ void	execute_external(t_mini *mini, char **argv, t_env *env_list, int *status)
 	return ;
 }
 
-void	execute_command(t_mini *mini, t_node *node, t_env *env_list, int * status)
+void	execute_command(t_mini *mini, t_node *node, t_env *env_list, int *status)
 {
 	t_builtin_type	builtin_type;
+	int				ret;
 
 	if (node == NULL)
 		return ;
 
-	do_redirection(mini, node->redirects);
+	// リダイレクト処理結果チェックを追加
+	ret = do_redirection(mini, node->redirects);
+	if (ret != 0)
+	{
+		// リダイレクト失敗時はコマンド実行せず終了ステータスを反映
+		*status = mini->status;
+		return;
+	}
+
 	builtin_type = get_builtin_type(node->argv[0]);
 	if (builtin_type != BUILTIN_UNKNOWN)
 		mini->status = execute_builtin(mini, builtin_type, node->argv, &env_list);
@@ -156,6 +165,7 @@ void	execute_command(t_mini *mini, t_node *node, t_env *env_list, int * status)
 	}
 	return ;
 }
+
 
 
 t_node	*process_command(t_node *node, int p_num)

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -3,66 +3,100 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mkaihori <nana7hachi89gmail.com>           +#+  +:+       +#+        */
+/*   By: nkannan <nkannan@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 12:29:30 by mkaihori          #+#    #+#             */
-/*   Updated: 2024/12/02 16:40:35 by mkaihori         ###   ########.fr       */
+/*   Updated: 2024/12/10 21:28:10 by nkannan          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-void	redirect_in(t_mini *mini, t_redirect *red)
+static int print_redirect_error(t_mini *mini, char *filename)
+{
+    fprintf(stderr, "minishell: %s: %s\n", filename, strerror(errno));
+    mini->status = 1;
+	return (1);
+}
+
+int	redirect_in(t_mini *mini, t_redirect *red)
 {
 	int	fd;
 
 	fd = open(red->file_name, O_RDONLY);
 	if (fd == -1)
-		system_error(mini);
+		return print_redirect_error(mini, red->file_name);
 	if (dup2(fd, STDIN_FILENO) == -1)
-		system_error(mini);
+	{
+		close(fd);
+		return print_redirect_error(mini, red->file_name);
+	}
 	close(fd);
-	return ;
+	return (0);
 }
 
-void	redirect_out(t_mini *mini, t_redirect *red)
+int	redirect_out(t_mini *mini, t_redirect *red)
 {
 	int	fd;
 
 	fd = open(red->file_name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	if (fd == -1)
-		system_error(mini);
+		return print_redirect_error(mini, red->file_name);
 	if (dup2(fd, STDOUT_FILENO) == -1)
-		system_error(mini);
+	{
+		close(fd);
+		return print_redirect_error(mini, red->file_name);
+	}
 	close(fd);
-	return ;
+	return (0);
 }
 
-void	redirect_append(t_mini *mini, t_redirect *red)
+int	redirect_append(t_mini *mini, t_redirect *red)
 {
 	int	fd;
 
 	fd = open(red->file_name, O_WRONLY | O_CREAT | O_APPEND, 0644);
 	if (fd == -1)
-		system_error(mini);
+		return print_redirect_error(mini, red->file_name);
 	if (dup2(fd, STDOUT_FILENO) == -1)
-		system_error(mini);
+	{
+		close(fd);
+		return print_redirect_error(mini, red->file_name);
+	}
 	close(fd);
-	return ;
+	return (0);
 }
 
 int	do_redirection(t_mini *mini, t_redirect *redirect)
 {
+	int	ret;
+
 	while (redirect)
 	{
 		if (redirect->type == REDIRECT_IN)
-			redirect_in(mini, redirect);
+		{
+			ret = redirect_in(mini, redirect);
+			if (ret != 0)
+				return ret;
+		}
 		else if (redirect->type == REDIRECT_OUT)
-			redirect_out(mini, redirect);
+		{
+			ret = redirect_out(mini, redirect);
+			if (ret != 0)
+				return ret;
+		}
 		else if (redirect->type == REDIRECT_APPEND)
-			redirect_append(mini, redirect);
+		{
+			ret = redirect_append(mini, redirect);
+			if (ret != 0)
+				return ret;
+		}
 		else if (redirect->type == REDIRECT_HEREDOC)
-			handle_heredoc(mini, redirect);
+		{
+			ret = handle_heredoc(mini, redirect);
+			if (ret != 0)
+				return ret;
+		}
 		redirect = redirect->next;
 	}
 	return (0);


### PR DESCRIPTION
**解説**  
今までのコードでは、リダイレクト時に`open()`が失敗すると`system_error()`でミニシェル自体を終了させていました。しかしbashは、リダイレクトファイルが見つからない場合などは"bash: filename: No such file or directory"といったエラーメッセージを標準エラーに出力し、exit codeを1にして、可能な場合はパイプラインの残りコマンドを実行します。  
上記修正では、`system_error()`を呼ばずに、`print_redirect_error()`でエラー出力と`mini->status`設定を行い、`do_redirection()`からエラーコードを返すように変更しました。`execute_command()`側でその戻り値を確認し、エラーならコマンド実行をスキップしつつ、`mini->status`を利用してエラーコードを反映しています。  
これにより、テストケースで要求されているbash同等の挙動（"No such file or directory"エラーや、パイプライン内での後続コマンド実行、exit codeの一致）が実現できます。