### PR TITLE
fix: refactor execute_pipeline to always use child processes for exec…

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -6,7 +6,7 @@
 /*   By: nkannan <nkannan@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 17:08:33 by nkannan           #+#    #+#             */
-/*   Updated: 2024/12/10 21:26:11 by nkannan          ###   ########.fr       */
+/*   Updated: 2024/12/10 21:51:36 by nkannan          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -259,11 +259,8 @@ void	execute_pipeline(t_mini *mini, t_node *node, int process)
 		return (execute_command(mini, node, mini->env, &(mini->status)));
 	while (p_num < process)
 	{
-		if (p_num == process - 1 && get_builtin_type(process_command(node, p_num)->argv[0]) != BUILTIN_UNKNOWN)
-		{
-			execute_builtin(mini, get_builtin_type(process_command(node, p_num)->argv[0]), process_command(node, p_num)->argv, &(mini->env));
-			break ;
-		}
+		// 以前はここで「最後がビルトインかどうか」を判断し、ビルトインなら親で直接execute_builtinをしていた。
+		// これを削除し、常にforkして子プロセスで実行。
 		mini->pid[p_num] = fork();
 		if (mini->pid[p_num] == -1)
 			system_error(mini);
@@ -274,6 +271,7 @@ void	execute_pipeline(t_mini *mini, t_node *node, int process)
 	parent_process(mini, mini->pipefd, process, mini->pid);
 	return ;
 }
+
 
 int	count_node(t_node *node)
 {


### PR DESCRIPTION
主にパイプライン処理で最後のコマンドがビルトインであった場合に直接親プロセスで実行してしまうロジックが問題となっている例です。  
Bashではパイプライン内の全てのコマンドはサブプロセス（子プロセス）として実行されますが、提示されたコードでは、最後のコマンドがビルトインである場合、親プロセスで直接実行する最適化が入っており、これがBashとの挙動差分を生んでいます。

テストケース（例：`echo hi | echo >>./outfiles/outfile01 bye`）では、Bashは`echo`コマンド（ビルトイン）もパイプライン中では子プロセスで実行し、redirection処理を正しく反映して`bye`をファイルに書き込み、標準出力には何も出力しません。一方、ミニシェル側は最後がビルトインだと親で直接実行していたため、redirectionが行われず（親で直接`execute_builtin()`を呼んでしまうため`do_redirection()`が行われない）、`bye`がそのまま標準出力へ出てしまっていました。  
また、redirection失敗時の挙動やパイプ内での終了ステータスの扱いもBashに合わせる必要があります。

**修正方針**  
`executor.c`内の`execute_pipeline()`関数で、最後のコマンドがビルトインでも親プロセスで直接実行せず、常にforkして子プロセスで実行するようにします。これでBash同様に全てのコマンドがパイプ内では子プロセスとなり、redirectionや終了ステータスがBashに近い形で処理されます。
